### PR TITLE
Fixed the split_text incosistency reported in issue #1

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,3 +5,6 @@ We need to make sure the maximum chunk size limit rule is followed, so probably 
 2) Integrate changing the model in use functionality to the GUI. Find a model that can handle a lot bigger tokens, probably the quality of the model will be poorer than OpenAIs but user should be able to do it. Make sure to mention all the limitations and related properties of the model in the GUI. 
 
 3) Implement error handling for cases where the prompt (chunks from docs + question) is bigger than the maximum token limit. Keep in mind that it'll be possible to use other models. So a LLM class that is flexible to use with any other model might be good to have.
+
+
+ssssss

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,15 @@ We need to make sure the maximum chunk size limit rule is followed, so probably 
 2) Integrate changing the model in use functionality to the GUI. Find a model that can handle a lot bigger tokens, probably the quality of the model will be poorer than OpenAIs but user should be able to do it. Make sure to mention all the limitations and related properties of the model in the GUI. 
 
 3) Implement error handling for cases where the prompt (chunks from docs + question) is bigger than the maximum token limit. Keep in mind that it'll be possible to use other models. So a LLM class that is flexible to use with any other model might be good to have.
+ 
 
 
-ssssss
+ ** do something to further balance prompt & completion length
+
+
+
+
+
+DOING:
+1) fixing the issue - 
+prompt: Что мне делать, когда у меня мало энергии и времени?

--- a/TalkWithYourFiles/text_processor.py
+++ b/TalkWithYourFiles/text_processor.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from langchain.text_splitter import CharacterTextSplitter
+from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain.embeddings.openai import OpenAIEmbeddings
 from langchain.vectorstores import FAISS
 
@@ -61,12 +62,21 @@ class DefaultTextProcessor(TextProcessor):
         list: The text chunks.
 
         """
-        text_splitter = CharacterTextSplitter(
-            separator="\n",
-            chunk_size=1000,
-            chunk_overlap=200,
+        # will be deprecated
+        # text_splitter = CharacterTextSplitter(
+        #     separator="\n",
+        #     chunk_size=1000,
+        #     chunk_overlap=200,
+        #     length_function=len
+        # )
+
+        text_splitter = RecursiveCharacterTextSplitter(
+            chunk_size=1000, 
+            chunk_overlap=100, 
+            separators=[" ", ",", "\n"],
             length_function=len
         )
+
         return text_splitter.split_text(text)
 
     def create_embeddings(self, chunks):


### PR DESCRIPTION
CharacterTextSplitter was creating chunks that're bigger than indicated maximum chunk size and this was causing to exceed the maximum token limits.

To overcome this:

- New separators were added: space & comma
- Replaced CharacterTextSplitter with RecursiveCharacterTextSplitter in the text_processor.py "This has the effect of trying to keep all paragraphs (and then sentences, and then words) together as long as possible, as those would generically seem to be the strongest semantically related pieces of text."